### PR TITLE
feat(): Connect each author to its own template, also display them on the carousel

### DIFF
--- a/src/cardsTemplates.ts
+++ b/src/cardsTemplates.ts
@@ -19,6 +19,7 @@ import pcEngineBG from './assets/pcengine_bg.svg';
 import animeOt4ku from './assets/tapto_0t4ku.svg';
 
 import { type SerializedGroupProps } from 'fabric';
+import { Authors } from './templateAuthors';
 
 export type templateLayer = {
   url: string;
@@ -51,16 +52,19 @@ export type templateType = {
   /* box-shadow like property for the main image, 3 numbers + color */
   shadow?: string;
   noMargin?: boolean;
+  author: Authors;
 };
 
 export const templates: Record<string, templateType> = {
   blankH: {
     layout: 'horizontal',
     label: 'Blank H cover',
+    author: Authors.andrea,
   },
   blankV: {
     layout: 'vertical',
     label: 'Blank V cover',
+    author: Authors.andrea,
   },
   blankHF: {
     layout: 'horizontal',
@@ -76,6 +80,7 @@ export const templates: Record<string, templateType> = {
       height: 0.96,
       isSvg: true,
     },
+    author: Authors.andrea,
   },
   blankVF: {
     layout: 'vertical',
@@ -91,6 +96,7 @@ export const templates: Record<string, templateType> = {
       height: 0.92,
       isSvg: true,
     },
+    author: Authors.andrea,
   },
   tapto2: {
     layout: 'horizontal',
@@ -112,6 +118,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'Tap-to H',
+    author: Authors.tim,
   },
   tapto3: {
     layout: 'vertical',
@@ -133,6 +140,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'Tap-to V',
+    author: Authors.tim
   },
   hucard: {
     layout: 'vertical',
@@ -154,6 +162,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'HuCard',
+    author: Authors.tim,
   },
   hucardc64: {
     layout: 'vertical',
@@ -175,6 +184,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'HuCard (C64)',
+    author: Authors.ben,
   },
   taptoGB: {
     layout: 'horizontal',
@@ -196,6 +206,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'Tap-to Gameboy',
+    author: Authors.ariel,
   },
   taptoFloppy: {
     layout: 'vertical',
@@ -216,6 +227,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'Floppy 3.5',
+    author: Authors.andrea,
   },
   taptoFloppy525: {
     layout: 'vertical',
@@ -236,6 +248,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'Floppy 5.25',
+    author: Authors.andrea,
   },
   tapToNes: {
     layout: 'vertical',
@@ -256,6 +269,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'Nes',
+    author: Authors.ariel,
   },
   tapToGenesis: {
     layout: 'vertical',
@@ -276,6 +290,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'Genesis',
+    author: Authors.ariel,
   },
   tapToPcEngine: {
     layout: 'vertical',
@@ -296,6 +311,7 @@ export const templates: Record<string, templateType> = {
       isSvg: true,
     },
     label: 'PcEngineCD',
+    author: Authors.ariel,
   },
   anime0taku: {
     layout: 'vertical',
@@ -311,6 +327,7 @@ export const templates: Record<string, templateType> = {
     },
     label: 'full image + system',
     noMargin: true,
+    author: Authors.animeotaku,
   }
 } as const;
 

--- a/src/components/Carousel.css
+++ b/src/components/Carousel.css
@@ -1,7 +1,7 @@
 .carousel-container {
   padding-top: 32px;
   min-height: 300px;
-  height: 300px;
+  height: 320px;
   overflow-x: scroll;
   overflow-y: hidden;
   padding-bottom: 32px;
@@ -22,8 +22,8 @@
 
 .carouselItem-externals {
   user-select: none;
-  height: 300px;
-  width: 300px;
+  height: 320px;
+  width: 320px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -36,7 +36,26 @@
   box-sizing: content-box;
 }
 
-.carouselItem:hover > img:last-child {
+.carouselCaption {
+  padding: 16px;
+  background-color: white;
+  border: 1px solid black;
+  position: absolute;
+  opacity: 0;
+  text-wrap: nowrap;
+  transition: opacity 0.25s linear;
+  pointer-events: none;
+}
+
+p.carouselCaption {
+  text-align: center;
+}
+
+.carouselCaption:hover, .carouselItem:hover + .carouselCaption {
+  opacity: 1;
+}
+
+.carouselItem:hover > img:last-child, .carouselCaption:hover + .carouselItem > img:last-child {
   box-shadow: 0px 0px 10px white ;
 }
 

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -3,6 +3,7 @@ import { templateType, templates } from '../cardsTemplates';
 import './Carousel.css';
 import { useAppDataContext } from '../contexts/appData';
 import { useFileAdder } from '../hooks/useFileAdder';
+import { templateAuthors } from '../templateAuthors';
 
 const TemplatesCarousel = () => {
   const { setTemplate } = useAppDataContext();
@@ -44,6 +45,13 @@ const TemplatesCarousel = () => {
                 {tData.background && <img src={tData.background.url} />}
                 {tData.overlay && <img src={tData.overlay.url} />}
               </div>
+              <Typography className="carouselCaption">
+                {tData.label}
+                <br />
+                by
+                <br />
+                {templateAuthors[tData.author].name}
+              </Typography>
             </div>
           ))}
         </div>

--- a/src/templateAuthors.ts
+++ b/src/templateAuthors.ts
@@ -3,21 +3,34 @@ type TemplateAuthors = {
   href: string;
 }
 
-export const templateAuthors: Record<string, TemplateAuthors> = {
-  ariel: {
+export const enum Authors {
+  ariel,
+  andrea,
+  tim,
+  animeotaku,
+  ben,
+}
+
+export const templateAuthors: Record<Authors, TemplateAuthors> = {
+  [Authors.ariel]: {
     name: 'Ariel Aces',
     href: 'https://www.artisticpixels305.com/',
   },
-  andrea: {
+  [Authors.andrea]: {
     name: 'Andrea Bogazzi',
     href: 'https://github.com/asturur',
   },
-  tim: {
+  [Authors.tim]: {
     name: 'Tim Wilsie',
     href: 'https://timwilsie.com/',
   },
-  animeotaku: {
+  [Authors.animeotaku]: {
     name: 'Anime0t4ku',
     href: 'https://github.com/Anime0t4ku/TapToCassetteCovers',
+  },
+  [Authors.ben]: {
+    name: 'Ben Squibb',
+    href: 'https://github.com/Stat-Mat',
   }
 } as const;
+


### PR DESCRIPTION
close #41

<img width="306" alt="image" src="https://github.com/user-attachments/assets/2a327988-dd5a-4769-9769-e90071cc17c0">
